### PR TITLE
Fix Similar Fatal Error in `SurveyQueueListener` After #3

### DIFF
--- a/includes/WPAdmin/Listeners/SurveyQueueListener.php
+++ b/includes/WPAdmin/Listeners/SurveyQueueListener.php
@@ -48,7 +48,7 @@ class SurveyQueueListener {
 
 			if ( is_readable( $asset_file ) ) {
 
-				$asset = include_once $asset_file;
+				$asset = include $asset_file;
 
 				wp_register_script(
 					'nfd-survey-surveys',


### PR DESCRIPTION
## Proposed changes

Fixes a similar fatal error that was resolved in https://github.com/newfold-labs/wp-module-survey/pull/3, but is now appearing in this file because the `DataAttrListener.php` error was fixed.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
