### PR TITLE
feat(i18n): Composer i18n scripts, catalogs, and auto-translate

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,0 +1,27 @@
+name: Check for Updates to Translations
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the branch that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  translate:
+    name: 'Check and update translations'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    with:
+      text_domain: 'wp-module-survey'
+    secrets:
+      TRANSLATOR_API_KEY: ${{ secrets.TRANSLATOR_API_KEY }}

--- a/composer.json
+++ b/composer.json
@@ -32,17 +32,42 @@
   ],
   "require-dev": {
     "newfold-labs/wp-php-standards": "^1.2",
-    "wp-cli/i18n-command": "^2.6.5",
+    "wp-cli/i18n-command": "^2.7.0",
     "johnpbloch/wordpress": "@stable",
     "lucatume/wp-browser": "*",
     "newfold-labs/wp-module-loader": "^1.0",
     "phpunit/phpcov": "*"
   },
   "scripts": {
+    "i18n": [
+      "@i18n-pot",
+      "@i18n-po",
+      "@i18n-php",
+      "@i18n-json"
+    ],
+    "i18n-ci-pre": [
+      "@i18n-pot",
+      "@i18n-po"
+    ],
+    "i18n-ci-post": [
+      "@i18n-json",
+      "@i18n-php"
+    ],
+    "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print --extensions=jsx",
+    "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
+    "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-survey.pot ./languages",
+    "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-survey.pot --domain=wp-module-survey --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-survey/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,build,vendor,wordpress,node_modules",
     "test": "codecept run wpunit",
     "test-coverage": "codecept run wpunit --coverage wpunit.cov && phpcov merge --php tests/_output/merged.cov --html tests/_output/html tests/_output && echo \"open tests/_output/html/index.html to view the report\""
   },
   "scripts-descriptions": {
+    "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+    "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+    "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+    "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+    "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+    "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+    "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
     "test": "Run wpunit tests.",
     "test-coverage": "Run wpunit tests with coverage."
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86f928dd90dffac196d89fa58e07cfc5",
+    "content-hash": "b62d2a42fb322b252d0d41bfebf7b67e",
     "packages": [],
     "packages-dev": [
         {
@@ -6158,16 +6158,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.6.6",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "94f72ddc4be8919f2cea181ba39cd140dd480d64"
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/94f72ddc4be8919f2cea181ba39cd140dd480d64",
-                "reference": "94f72ddc4be8919f2cea181ba39cd140dd480d64",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/e91e6903d212486e32ed2c916171f661bfc539ce",
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce",
                 "shasum": ""
             },
             "require": {
@@ -6189,6 +6189,7 @@
                 "bundled": true,
                 "commands": [
                     "i18n",
+                    "i18n audit",
                     "i18n make-pot",
                     "i18n make-json",
                     "i18n make-mo",
@@ -6221,9 +6222,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.6"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.7.0"
             },
-            "time": "2025-11-21T04:23:34+00:00"
+            "time": "2026-03-16T17:13:39+00:00"
         },
         {
             "name": "wp-cli/mustache",
@@ -6650,5 +6651,5 @@
     "platform-overrides": {
         "php": "7.4.33"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/languages/wp-module-survey-de_DE-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-de_DE-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "de",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-de_DE.l10n.php
+++ b/languages/wp-module-survey-de_DE.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'de',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-de_DE.po
+++ b/languages/wp-module-survey-de_DE.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: de\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-en_AU-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-en_AU-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "en_AU",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                "Comment"
+            ],
+            "Angry": [
+                "Angry"
+            ],
+            "Not Happy (Sad)": [
+                "Not Happy (Sad)"
+            ],
+            "Lame": [
+                "Lame"
+            ],
+            "Smiley": [
+                "Smiley"
+            ],
+            "Happy": [
+                "Happy"
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-en_AU.l10n.php
+++ b/languages/wp-module-survey-en_AU.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'en_AU',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+		'wp-module-survey' => 'wp-module-survey',
+	],
+];

--- a/languages/wp-module-survey-en_AU.po
+++ b/languages/wp-module-survey-en_AU.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: en_AU\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr "wp-module-survey"
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr "Comment"
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr "Angry"
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr "Not Happy (Sad)"
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr "Lame"
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr "Smiley"
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr "Happy"

--- a/languages/wp-module-survey-en_GB-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-en_GB-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "en_GB",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                "Comment"
+            ],
+            "Angry": [
+                "Angry"
+            ],
+            "Not Happy (Sad)": [
+                "Not Happy (Sad)"
+            ],
+            "Lame": [
+                "Lame"
+            ],
+            "Smiley": [
+                "Smiley"
+            ],
+            "Happy": [
+                "Happy"
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-en_GB.l10n.php
+++ b/languages/wp-module-survey-en_GB.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'en_GB',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+		'wp-module-survey' => 'wp-module-survey',
+	],
+];

--- a/languages/wp-module-survey-en_GB.po
+++ b/languages/wp-module-survey-en_GB.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: en_GB\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr "wp-module-survey"
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr "Comment"
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr "Angry"
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr "Not Happy (Sad)"
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr "Lame"
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr "Smiley"
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr "Happy"

--- a/languages/wp-module-survey-es_ES-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-es_ES-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "es",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-es_ES.l10n.php
+++ b/languages/wp-module-survey-es_ES.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'es',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-es_ES.po
+++ b/languages/wp-module-survey-es_ES.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: es\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-es_MX-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-es_MX-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "es_MX",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-es_MX.l10n.php
+++ b/languages/wp-module-survey-es_MX.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'es_MX',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-es_MX.po
+++ b/languages/wp-module-survey-es_MX.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: es_MX\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-fr_FR-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-fr_FR-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "fr",
+                "plural-forms": "nplurals=2; plural=(n > 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-fr_FR.l10n.php
+++ b/languages/wp-module-survey-fr_FR.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n > 1);',
+	'language' => 'fr',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-fr_FR.po
+++ b/languages/wp-module-survey-fr_FR.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: fr\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-it_IT-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-it_IT-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "it",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-it_IT.l10n.php
+++ b/languages/wp-module-survey-it_IT.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'it',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-it_IT.po
+++ b/languages/wp-module-survey-it_IT.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: it\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-nl_NL-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-nl_NL-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "nl",
+                "plural-forms": "nplurals=2; plural=(n != 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-nl_NL.l10n.php
+++ b/languages/wp-module-survey-nl_NL.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'nl',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-nl_NL.po
+++ b/languages/wp-module-survey-nl_NL.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: nl\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey-pt_BR-d1c8e68901ec3e662b1bcb74d588734e.json
+++ b/languages/wp-module-survey-pt_BR-d1c8e68901ec3e662b1bcb74d588734e.json
@@ -1,0 +1,33 @@
+{
+    "translation-revision-date": "2026-04-03T19:13:37+00:00",
+    "generator": "WP-CLI\/2.12.0",
+    "source": "src\/Surveys\/components\/Toast\/index.jsx",
+    "domain": "messages",
+    "locale_data": {
+        "messages": {
+            "": {
+                "domain": "messages",
+                "lang": "pt_BR",
+                "plural-forms": "nplurals=2; plural=(n > 1);"
+            },
+            "Comment": [
+                ""
+            ],
+            "Angry": [
+                ""
+            ],
+            "Not Happy (Sad)": [
+                ""
+            ],
+            "Lame": [
+                ""
+            ],
+            "Smiley": [
+                ""
+            ],
+            "Happy": [
+                ""
+            ]
+        }
+    }
+}

--- a/languages/wp-module-survey-pt_BR.l10n.php
+++ b/languages/wp-module-survey-pt_BR.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-survey',
+	'plural-forms' => 'nplurals=2; plural=(n > 1);',
+	'language' => 'pt_BR',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:37+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-survey-pt_BR.po
+++ b/languages/wp-module-survey-pt_BR.po
@@ -1,0 +1,43 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:37+00:00\n"
+"Language: pt_BR\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""

--- a/languages/wp-module-survey.pot
+++ b/languages/wp-module-survey.pot
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-survey/issues\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-survey\n"
+
+#: bootstrap.php:17
+msgid "wp-module-survey"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:33
+msgid "Comment"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:53
+msgid "Angry"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:59
+msgid "Not Happy (Sad)"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:65
+msgid "Lame"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:71
+msgid "Smiley"
+msgstr ""
+
+#: src/Surveys/components/Toast/index.jsx:77
+msgid "Happy"
+msgstr ""


### PR DESCRIPTION
Adds Composer i18n scripts (i18n-pot/po/php/json, i18n-ci-pre/post), wp-cli/i18n-command in require-dev, languages/ (POT, PO, l10n.php, JSON where applicable), and auto-translate workflow where missing. Aligns text domains with wp-module-* where noted in the i18n rollout plan.

P0/P1 implementation per org standard (coming-soon pattern).

Made with [Cursor](https://cursor.com)