### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -11,6 +11,9 @@ on:
       - '!build/**/*.php'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/newfold-labs/wp-module-survey/security/code-scanning/9](https://github.com/newfold-labs/wp-module-survey/security/code-scanning/9)

Add an explicit workflow-level `permissions` block in `.github/workflows/lint-checker-php.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix (without changing functionality): add:

```yml
permissions:
  contents: read
```

near the top-level keys (for example, after `workflow_dispatch:` and before `concurrency:`).  
This is sufficient for checkout/read operations and documents intent. No imports, methods, or external definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
