### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,6 +5,8 @@ on:
     types:
       - created
 
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook


### PR DESCRIPTION
Potential fix for [https://github.com/newfold-labs/wp-module-survey/security/code-scanning/1](https://github.com/newfold-labs/wp-module-survey/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default. Since this workflow only computes values and calls `repository-dispatch` with `secrets.WEBHOOK_TOKEN`, it does not need repository write scopes from `GITHUB_TOKEN`. The safest minimal change is to set `permissions: {}` at the workflow root (applies to all jobs unless overridden), which grants no permissions to `GITHUB_TOKEN`.

Edit `.github/workflows/satis-update.yml` near the top-level keys (after `on:` and before `jobs:`) to include:
- `permissions: {}`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
